### PR TITLE
履歴の選択の挙動が一部想定と異なっていた事象の修正

### DIFF
--- a/src/app/component/chat/chat-input/chat-input.component.html
+++ b/src/app/component/chat/chat-input/chat-input.component.html
@@ -9,10 +9,10 @@
           placeholder='Enterで送信　Shift+Enterで改行　Ctrl+上下で履歴移動'
           [ngModelOptions]="{standalone: true}" (input)="onInput()" (keydown.enter)="sendChat($event)"
           (keydown.control.arrowup)="moveHistory($event, -1)" (keydown.control.arrowdown)="moveHistory($event, 1)"
-          (keydown.control.0)="selectHistory($event,9)" (keydown.esc)="cancel()"
-          (keydown.control.1)="selectHistory($event,0)" (keydown.control.2)="selectHistory($event,1)" (keydown.control.3)="selectHistory($event,2)"
-          (keydown.control.4)="selectHistory($event,3)" (keydown.control.5)="selectHistory($event,4)" (keydown.control.6)="selectHistory($event,5)"
-          (keydown.control.7)="selectHistory($event,6)" (keydown.control.8)="selectHistory($event,7)" (keydown.control.9)="selectHistory($event,8)"
+          (keydown.control.0)="selectHistory($event,0)" (keydown.esc)="cancel()"
+          (keydown.control.1)="selectHistory($event,9)" (keydown.control.2)="selectHistory($event,8)" (keydown.control.3)="selectHistory($event,7)"
+          (keydown.control.4)="selectHistory($event,6)" (keydown.control.5)="selectHistory($event,5)" (keydown.control.6)="selectHistory($event,4)"
+          (keydown.control.7)="selectHistory($event,3)" (keydown.control.8)="selectHistory($event,2)" (keydown.control.9)="selectHistory($event,1)"
           #textArea>
         </textarea>
         <button type="submit" class="send" (click)="sendChat(null)"><b>SEND</b></button>

--- a/src/app/component/chat/chat-input/chat-input.component.ts
+++ b/src/app/component/chat/chat-input/chat-input.component.ts
@@ -206,14 +206,13 @@ export class ChatInputComponent implements OnInit  ,AfterViewInit  , OnDestroy {
 
   selectHistory(event :Event ,index :number) {
     if (event) event.preventDefault();
-    let minIndex = 9 - this.history.length + 1;
-    if (minIndex > index) {
+    const targetIndex = this.history.length - 1 - index;
+    if (targetIndex < 0) {
       let textArea: HTMLTextAreaElement = this.textAreaElementRef.nativeElement;
       textArea.focus();
       return;
     }
-    if (this.currentHistoryIndex < 0) this.currentHistoryIndex = this.history.length - 1;
-    this.currentHistoryIndex -= (9 - index);
+    this.currentHistoryIndex = targetIndex;
     this.historyToText()
   }
 


### PR DESCRIPTION
Ctrl+0-9で履歴の文字列を選択した直後に、もう一度Ctrl+0-9で別の履歴の選択をしようとすると、想定されたものとは別の履歴が選択される問題を修正しました

想定した挙動: 表示上のCtrl+0-9に対応した履歴が入力エリアに表示される

実際の挙動: 最初の手順に選択した履歴の場所がCtrl+0の基準となり、そこからCtrl+9,8...という番号に対応した履歴が入力エリアに表示される

これが意図した挙動の場合はCloseしていただいて構いません。